### PR TITLE
fix(hash-object): add content length to object file

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -74,7 +74,8 @@ func HashObject(path, objectType string, shouldWrite bool) (string, error) {
 		return "", err
 	}
 
-	combined := append([]byte(objectType), '\x00')
+	combined := append([]byte(objectType), []byte(fmt.Sprintf(" %v", len(fileContent)))...)
+	combined = append(combined, '\x00')
 	combined = append(combined, fileContent...)
 	sha1Sum := sha1.Sum(combined)
 	hexSum := hex.EncodeToString(sha1Sum[:])

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -66,7 +66,8 @@ func TestHashBlobObjectNotWriteToDisk(t *testing.T) {
 		t.Fatalf("HashObject return error: %v", err)
 	}
 
-	combined := append([]byte("blob"), '\x00')
+	combined := append([]byte("blob"), []byte(" 5")...)
+	combined = append(combined, '\x00')
 	combined = append(combined, []byte("Hello")...)
 	shaSum := sha1.Sum(combined)
 	expected := hex.EncodeToString(shaSum[:])
@@ -98,7 +99,8 @@ func TestHashBlobObjectWriteToDisk(t *testing.T) {
 		t.Fatalf("HashObject return error: %v", err)
 	}
 
-	combined := append([]byte("blob"), '\x00')
+	combined := append([]byte("blob"), []byte(" 5")...)
+	combined = append(combined, '\x00')
 	combined = append(combined, []byte("Hello")...)
 	shaSum := sha1.Sum(combined)
 	expected := hex.EncodeToString(shaSum[:])


### PR DESCRIPTION
```
blob <content length> \x00 <content>
```